### PR TITLE
build: update authkit rollup typescript exclude

### DIFF
--- a/packages/authkit/rollup.config.mjs
+++ b/packages/authkit/rollup.config.mjs
@@ -39,7 +39,10 @@ export default [
       resolve(),
       commonjs(),
       image(),
-      typescript({ tsconfig: "./tsconfig.json", exclude: ["**/stories/*"] }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        exclude: ["src/stories/**/*"],
+      }),
       postcss(),
       terser(),
     ],


### PR DESCRIPTION
typescript exclude 的路径规则写错了，会生成多余的类型定义文件